### PR TITLE
fix: Use space instead of linebreak to separate URLs

### DIFF
--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -4,13 +4,13 @@ set -ex
 
 SMDATA_DIR="$1"
 
-FRAXTIL_URLS='https://fra.xtil.net/simfiles/data/tsunamix/III/Tsunamix%20III%20%5BSM5%5D.zip
-https://fra.xtil.net/simfiles/data/arrowarrangements/Fraxtil%27s%20Arrow%20Arrangements%20%5BSM5%5D.zip
-https://fra.xtil.net/simfiles/data/beastbeats/Fraxtil%27s%20Beast%20Beats%20%5BSM5%5D.zip
-'
-ITG_URLS='https://search.stepmaniaonline.net/static/new/In%20The%20Groove%201.zip
-https://search.stepmaniaonline.net/static/new/In%20The%20Groove%202.zip
-'
+FRAXTIL_URLS="https://fra.xtil.net/simfiles/data/tsunamix/III/Tsunamix%20III%20%5BSM5%5D.zip \
+https://fra.xtil.net/simfiles/data/arrowarrangements/Fraxtil%27s%20Arrow%20Arrangements%20%5BSM5%5D.zip \
+https://fra.xtil.net/simfiles/data/beastbeats/Fraxtil%27s%20Beast%20Beats%20%5BSM5%5D.zip \
+"
+ITG_URLS="https://search.stepmaniaonline.net/static/new/In%20The%20Groove%201.zip \
+https://search.stepmaniaonline.net/static/new/In%20The%20Groove%202.zip \
+"
 
 mkdir -p $SMDATA_DIR/raw
 pushd $SMDATA_DIR/raw


### PR DESCRIPTION
Fix the download error in #1.
Package not found issue in mac still remains.